### PR TITLE
feat: lazy-load user avatars and event covers

### DIFF
--- a/api/events.ts
+++ b/api/events.ts
@@ -11,6 +11,10 @@ function listEvents (params?: ListEventsParams): Promise<Paginated<EventListItem
   return axiosInstance.get('admin/events', { params }).then(req => req.data)
 }
 
+function getEventCover (eventId: string): Promise<{ cover: string | null }> {
+  return axiosInstance.get(`events/${eventId}/cover`).then(req => req.data)
+}
+
 function createEvent (event: Event): Promise<Event> {
   return axiosInstance.post('events/', event).then(req => req.data)
 }
@@ -45,6 +49,7 @@ function toggleAutoApprove(): Promise<EventApprovalSettings> {
 
 export default {
   listEvents,
+  getEventCover,
   createEvent,
   updateEvent,
   deleteEvent,

--- a/api/users.ts
+++ b/api/users.ts
@@ -13,6 +13,10 @@ function listUsers(params?: ListUsersParams): Promise<Paginated<UserListItem>> {
   return axiosInstance.get('/admin/users', { params }).then(req => req.data)
 }
 
+function getUserAvatar (userId: string): Promise<{ avatar: string | null }> {
+  return axiosInstance.get(`profile/${userId}/avatar`).then(req => req.data)
+}
+
 function getUserById (userId: string): Promise<UserProfile> {
   return axiosInstance.get(`profile/${userId}`).then(req => req.data)
 }
@@ -52,6 +56,7 @@ function uploadAllowedEmailsXls (file: File): Promise<{success: true, message: s
 
 export default {
   listUsers,
+  getUserAvatar,
   getUserById,
   listBannedUsers,
   banUser,

--- a/components/event/EventCover.vue
+++ b/components/event/EventCover.vue
@@ -2,6 +2,9 @@
 import { ref, onMounted } from 'vue'
 import eventsApi from '~/api/events'
 
+// Module-level cache — survives component unmount/remount (navigation away & back)
+const cache = new Map<string, string | null>()
+
 const props = defineProps<{
   eventId: string
   title?: string
@@ -11,11 +14,16 @@ const props = defineProps<{
 const cover = ref<string | null>(null)
 
 onMounted(async () => {
+  if (cache.has(props.eventId)) {
+    cover.value = cache.get(props.eventId) ?? null
+    return
+  }
   try {
     const data = await eventsApi.getEventCover(props.eventId)
+    cache.set(props.eventId, data.cover)
     cover.value = data.cover
   } catch {
-    // fallback to placeholder
+    cache.set(props.eventId, null)
   }
 })
 </script>

--- a/components/event/EventCover.vue
+++ b/components/event/EventCover.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import eventsApi from '~/api/events'
+
+const props = defineProps<{
+  eventId: string
+  title?: string
+  size?: string
+}>()
+
+const cover = ref<string | null>(null)
+
+onMounted(async () => {
+  try {
+    const data = await eventsApi.getEventCover(props.eventId)
+    cover.value = data.cover
+  } catch {
+    // fallback to placeholder
+  }
+})
+</script>
+
+<template>
+  <img
+    v-if="cover"
+    :src="`data:image/jpeg;base64,${cover}`"
+    :class="size ?? 'h-10 w-10'"
+    class="flex-shrink-0 rounded-full object-cover"
+    :alt="title ?? 'Event cover'"
+  >
+  <div
+    v-else
+    :class="size ?? 'h-10 w-10'"
+    class="flex-shrink-0 rounded-full bg-gray-200"
+  />
+</template>

--- a/components/event/EventTable.vue
+++ b/components/event/EventTable.vue
@@ -2,13 +2,14 @@
 import Approve from '@/assets/icons/misc/button__approve.svg'
 import Reject from '@/assets/icons/misc/button__reject.svg'
 import Edit from '@/assets/icons/misc/button__edit.svg'
-import type { Event } from '~/types';
+import type { EventListItem } from '~/types';
 import SmallIcon from '../common/SmallIcon.vue';
 import DefaultIcon from '../common/DefaultIcon.vue';
 import DefaultSeparator from '../common/DefaultSeparator.vue';
+import EventCover from '../event/EventCover.vue';
 
 defineProps<{
-  events: Event[]
+  events: EventListItem[]
 }>()
 
 const emit = defineEmits(['approve', 'reject'])
@@ -17,7 +18,7 @@ const edit = (id: string) => {
   navigateTo(`/events/${id}`)
 }
 
-const getStatusBadge = (event: Event) => {
+const getStatusBadge = (event: EventListItem) => {
   if (event.approved === true) return { text: 'Approved', class: 'bg-green-100 text-green-800' }
   if (event.approved === false) return { text: 'Rejected', class: 'bg-red-100 text-red-800' }
   return { text: 'Pending', class: 'bg-yellow-100 text-yellow-800' }
@@ -55,11 +56,7 @@ const getStatusBadge = (event: Event) => {
         <div class="grid grid-cols-12 items-center px-4 py-4 hover:bg-gray-50">
           <!-- Event Info -->
           <div class="col-span-4 flex items-center space-x-3">
-            <img 
-              :src="`data:image/jpeg;base64,${event.cover}`" 
-              class="h-10 w-10 flex-shrink-0 rounded-full"
-              :alt="event.title"
-            >
+            <EventCover :event-id="event.id" :title="event.title" />
             <span class="text-sm font-medium text-gray-900">
               {{ event.title }}
             </span>

--- a/components/user/UserAvatar.vue
+++ b/components/user/UserAvatar.vue
@@ -3,6 +3,9 @@ import { ref, onMounted } from 'vue'
 import { UserCircleIcon } from '@heroicons/vue/24/solid'
 import usersApi from '~/api/users'
 
+// Module-level cache — survives component unmount/remount (navigation away & back)
+const cache = new Map<string, string | null>()
+
 const props = defineProps<{
   userId: string
   size?: string
@@ -11,11 +14,16 @@ const props = defineProps<{
 const avatar = ref<string | null>(null)
 
 onMounted(async () => {
+  if (cache.has(props.userId)) {
+    avatar.value = cache.get(props.userId) ?? null
+    return
+  }
   try {
     const data = await usersApi.getUserAvatar(props.userId)
+    cache.set(props.userId, data.avatar)
     avatar.value = data.avatar
   } catch {
-    // fallback to icon
+    cache.set(props.userId, null)
   }
 })
 </script>

--- a/components/user/UserAvatar.vue
+++ b/components/user/UserAvatar.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { UserCircleIcon } from '@heroicons/vue/24/solid'
+import usersApi from '~/api/users'
+
+const props = defineProps<{
+  userId: string
+  size?: string
+}>()
+
+const avatar = ref<string | null>(null)
+
+onMounted(async () => {
+  try {
+    const data = await usersApi.getUserAvatar(props.userId)
+    avatar.value = data.avatar
+  } catch {
+    // fallback to icon
+  }
+})
+</script>
+
+<template>
+  <img
+    v-if="avatar"
+    :src="`data:image/jpeg;base64,${avatar}`"
+    :class="size ?? 'w-10 h-10'"
+    class="rounded-full object-cover flex-shrink-0"
+    alt="User avatar"
+  >
+  <UserCircleIcon
+    v-else
+    :class="size ?? 'w-10 h-10'"
+    class="text-gray-400 flex-shrink-0"
+  />
+</template>

--- a/components/user/UserTable.vue
+++ b/components/user/UserTable.vue
@@ -9,6 +9,7 @@ import { UserCircleIcon as OutlineUserCircleIcon } from "@heroicons/vue/24/outli
 import type { UserListItem } from "~/types";
 import { useUsersStore } from "~/store/users";
 import { reactive } from "vue";
+import UserAvatar from "~/components/user/UserAvatar.vue";
 
 interface Props {
     users: UserListItem[];
@@ -156,16 +157,7 @@ const handleFilterChange = (
         <!-- Mobile Card -->
         <div class="md:hidden border-t p-4 hover:bg-gray-50">
           <div class="flex items-start gap-3">
-            <img
-              v-if="user.avatar"
-              :src="`data:image/jpeg;base64,${user.avatar}`"
-              class="w-10 h-10 rounded-full object-cover"
-              alt="User avatar"
-            >
-            <UserCircleIcon
-              v-else
-              class="w-10 h-10 text-gray-400"
-            />
+            <UserAvatar :user-id="user.id" />
             <div class="flex-1 min-w-0">
               <div class="flex justify-between items-start">
                 <h4 class="font-medium text-gray-900 truncate">
@@ -250,16 +242,7 @@ const handleFilterChange = (
           class="hidden md:grid grid-cols-12 items-center p-4 hover:bg-gray-50 border-t"
         >
           <div class="col-span-4 flex items-center gap-3">
-            <img
-              v-if="user.avatar"
-              :src="`data:image/jpeg;base64,${user.avatar}`"
-              class="w-10 h-10 rounded-full object-cover"
-              alt="User avatar"
-            >
-            <UserCircleIcon
-              v-else
-              class="w-10 h-10 text-gray-400"
-            />
+            <UserAvatar :user-id="user.id" />
             <span class="font-medium truncate">{{
               user.name
             }}</span>


### PR DESCRIPTION
## Summary

Replaces inline base64 images in list views with lazy-loaded per-item components that fetch from the new dedicated backend endpoints.

### Changes

**API layer**
- `api/users.ts` — `getUserAvatar(userId)` → `GET /profile/{id}/avatar`
- `api/events.ts` — `getEventCover(eventId)` → `GET /events/{id}/cover`

**New components**
- `components/user/UserAvatar.vue` — fetches avatar on mount, shows `UserCircleIcon` until loaded
- `components/event/EventCover.vue` — fetches cover on mount, shows gray placeholder until loaded

**Updated components**
- `components/user/UserTable.vue` — replaced inline `v-if="user.avatar"` img block with `<UserAvatar>`
- `components/event/EventTable.vue` — fixed prop type `Event[]` → `EventListItem[]`, replaced `event.cover` img with `<EventCover>`

### Result
List pages load fast (no images in the initial payload). Images fill in asynchronously per row as components mount.

### Related
Backend PR: iu-alumni/iu-alumni-backend feat/lazy-image-endpoints