### PR TITLE
ci: standardize required check naming

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  test-and-build:
+  validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
         run: pnpm run build
 
   build-image:
-    needs: test-and-build
+    needs: validate
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Closes #69

Standardizes workflow job naming so emitted check contexts match required branch-protection checks.