### PR TITLE
feat(badges): admin portal /badges page + user award action [#14]

### DIFF
--- a/api/badges.ts
+++ b/api/badges.ts
@@ -1,0 +1,51 @@
+import type { BadgeAwardsResponse, BadgeCatalogItem } from "~/types";
+import axiosInstance from ".";
+
+function listBadges(): Promise<BadgeCatalogItem[]> {
+  return axiosInstance
+    .get("/api/v1/admin/badges")
+    .then((r) => r.data);
+}
+
+function listAwards(code: string): Promise<BadgeAwardsResponse> {
+  return axiosInstance
+    .get(`/api/v1/admin/badges/${encodeURIComponent(code)}/awards`)
+    .then((r) => r.data);
+}
+
+function awardBadge(payload: {
+  alumni_id: string;
+  badge_code: string;
+  metadata?: Record<string, unknown>;
+}): Promise<unknown> {
+  return axiosInstance
+    .post("/api/v1/admin/badges/award", payload)
+    .then((r) => r.data);
+}
+
+function revokeBadge(payload: {
+  alumni_id: string;
+  badge_code: string;
+  metadata?: Record<string, unknown>;
+}): Promise<unknown> {
+  return axiosInstance
+    .post("/api/v1/admin/badges/revoke", payload)
+    .then((r) => r.data);
+}
+
+function recomputeLeaderboards(
+  year?: number
+): Promise<{ year: number; awarded: number }> {
+  const params = year !== undefined ? { year } : undefined;
+  return axiosInstance
+    .post("/api/v1/admin/badges/recompute-leaderboards", null, { params })
+    .then((r) => r.data);
+}
+
+export default {
+  listBadges,
+  listAwards,
+  awardBadge,
+  revokeBadge,
+  recomputeLeaderboards,
+};

--- a/components/badge/AwardBadgeButton.vue
+++ b/components/badge/AwardBadgeButton.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import DefaultButton from '~/components/common/DefaultButton.vue';
+import badgesApi from '~/api/badges';
+import { useToast } from '~/components/ui/toast/use-toast';
+import type { BadgeCatalogItem } from '~/types';
+
+const props = defineProps<{
+  alumniId: string;
+  userLabel?: string;
+}>();
+
+const emit = defineEmits<{ (e: 'awarded'): void }>();
+
+const { toast } = useToast();
+const isOpen = ref(false);
+const catalog = ref<BadgeCatalogItem[]>([]);
+const selectedCode = ref('');
+const isSubmitting = ref(false);
+
+const load = async () => {
+  if (catalog.value.length) return;
+  try {
+    catalog.value = await badgesApi.listBadges();
+  } catch {
+    toast({ variant: 'destructive', title: 'Failed to load catalog' });
+  }
+};
+
+onMounted(load);
+
+const open = async () => {
+  await load();
+  selectedCode.value = '';
+  isOpen.value = true;
+};
+
+const submit = async () => {
+  if (!selectedCode.value) {
+    toast({ variant: 'destructive', title: 'Pick a badge first' });
+    return;
+  }
+  isSubmitting.value = true;
+  try {
+    await badgesApi.awardBadge({
+      alumni_id: props.alumniId,
+      badge_code: selectedCode.value,
+    });
+    toast({ title: 'Badge awarded' });
+    isOpen.value = false;
+    emit('awarded');
+  } catch (e: unknown) {
+    const detail =
+      (e as { response?: { data?: { detail?: string } } })?.response?.data
+        ?.detail ?? 'Award failed';
+    toast({ variant: 'destructive', title: detail });
+  } finally {
+    isSubmitting.value = false;
+  }
+};
+</script>
+
+<template>
+  <DefaultButton
+    type="inactive"
+    size="small"
+    @click="open"
+  >
+    Award badge
+  </DefaultButton>
+  <div
+    v-if="isOpen"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+    @click.self="isOpen = false"
+  >
+    <div class="bg-white rounded-md shadow-2xl border border-bluegray p-6 w-[400px]">
+      <h3 class="text-lg font-semibold mb-1">
+        Award a badge
+      </h3>
+      <p
+        v-if="userLabel"
+        class="text-sm text-gray-600 mb-4"
+      >
+        Recipient: <span class="font-medium">{{ userLabel }}</span>
+      </p>
+      <label class="text-xs uppercase tracking-wide text-gray-500">
+        Badge
+      </label>
+      <select
+        v-model="selectedCode"
+        class="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brandgreen"
+      >
+        <option
+          value=""
+          disabled
+        >
+          Pick a badge…
+        </option>
+        <option
+          v-for="b in catalog"
+          :key="b.code"
+          :value="b.code"
+        >
+          {{ b.name }} ({{ b.tier }})
+        </option>
+      </select>
+      <div class="flex justify-end gap-2 mt-6">
+        <DefaultButton
+          type="inactive"
+          size="small"
+          :disabled="isSubmitting"
+          @click="isOpen = false"
+        >
+          Cancel
+        </DefaultButton>
+        <DefaultButton
+          size="small"
+          :disabled="isSubmitting"
+          @click="submit"
+        >
+          {{ isSubmitting ? 'Awarding…' : 'Award' }}
+        </DefaultButton>
+      </div>
+    </div>
+  </div>
+</template>

--- a/components/badge/BadgeAwardsPanel.vue
+++ b/components/badge/BadgeAwardsPanel.vue
@@ -1,0 +1,144 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import DefaultButton from '~/components/common/DefaultButton.vue';
+import SimpleLoader from '~/components/common/SimpleLoader.vue';
+import badgesApi from '~/api/badges';
+import { useToast } from '~/components/ui/toast/use-toast';
+import type { BadgeAward, BadgeAwardsResponse } from '~/types';
+
+const props = defineProps<{
+  code: string | null;
+}>();
+
+const emit = defineEmits<{
+  (e: 'revoked', code: string): void;
+  (e: 'close'): void;
+}>();
+
+const { toast } = useToast();
+const data = ref<BadgeAwardsResponse | null>(null);
+const isLoading = ref(false);
+const revokingKey = ref<string | null>(null);
+
+const rows = computed<BadgeAward[]>(() => data.value?.awards ?? []);
+
+const load = async () => {
+  if (!props.code) return;
+  isLoading.value = true;
+  try {
+    data.value = await badgesApi.listAwards(props.code);
+  } catch {
+    toast({ variant: 'destructive', title: 'Failed to load awards' });
+  } finally {
+    isLoading.value = false;
+  }
+};
+
+watch(() => props.code, load, { immediate: true });
+
+const rowKey = (r: BadgeAward): string =>
+  `${r.alumni_id}::${JSON.stringify(r.extra)}`;
+
+const revoke = async (row: BadgeAward) => {
+  if (!props.code) return;
+  const key = rowKey(row);
+  revokingKey.value = key;
+  try {
+    await badgesApi.revokeBadge({
+      alumni_id: row.alumni_id,
+      badge_code: props.code,
+      metadata: Object.keys(row.extra).length ? row.extra : undefined,
+    });
+    toast({ title: 'Badge revoked' });
+    emit('revoked', props.code);
+    await load();
+  } catch {
+    toast({ variant: 'destructive', title: 'Revoke failed' });
+  } finally {
+    revokingKey.value = null;
+  }
+};
+
+const extraLabel = (extra: Record<string, unknown>): string => {
+  const parts = Object.entries(extra).map(([k, v]) => `${k}: ${v}`);
+  return parts.join(' · ');
+};
+
+const formatDate = (iso: string | null): string => {
+  if (!iso) return '—';
+  return new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+  }).format(new Date(iso));
+};
+</script>
+
+<template>
+  <div class="border-l border-gray-200 bg-white p-4 h-full flex flex-col">
+    <div class="flex items-start justify-between mb-4">
+      <div>
+        <div class="text-xs text-gray-500 uppercase tracking-wide">
+          Holders
+        </div>
+        <h3 class="text-lg font-semibold text-gray-900">
+          {{ data?.name ?? code }}
+        </h3>
+      </div>
+      <button
+        class="text-gray-400 hover:text-gray-600 text-xl leading-none"
+        @click="emit('close')"
+      >
+        ×
+      </button>
+    </div>
+    <div
+      v-if="isLoading"
+      class="flex items-center justify-center py-10"
+    >
+      <SimpleLoader />
+    </div>
+    <div
+      v-else-if="!rows.length"
+      class="text-sm text-gray-500 py-8 text-center"
+    >
+      Nobody has earned this badge yet.
+    </div>
+    <div
+      v-else
+      class="flex-1 overflow-y-auto divide-y divide-gray-100"
+    >
+      <div
+        v-for="row in rows"
+        :key="rowKey(row)"
+        class="py-3 flex items-center justify-between gap-3"
+      >
+        <div class="min-w-0">
+          <div class="text-sm font-medium text-gray-900 truncate">
+            {{ row.first_name }} {{ row.last_name }}
+          </div>
+          <div class="text-xs text-gray-500 truncate">
+            {{ row.email }}
+          </div>
+          <div
+            v-if="Object.keys(row.extra).length"
+            class="text-xs text-brandgreen font-medium mt-0.5"
+          >
+            {{ extraLabel(row.extra) }}
+          </div>
+          <div class="text-xs text-gray-400 mt-0.5">
+            Awarded {{ formatDate(row.awarded_at) }}<span v-if="row.awarded_by"> · by admin</span>
+          </div>
+        </div>
+        <DefaultButton
+          size="small"
+          type="inactive"
+          :disabled="revokingKey === rowKey(row)"
+          @click="revoke(row)"
+        >
+          {{ revokingKey === rowKey(row) ? 'Revoking…' : 'Revoke' }}
+        </DefaultButton>
+      </div>
+    </div>
+  </div>
+</template>

--- a/components/badge/BadgeTierPill.vue
+++ b/components/badge/BadgeTierPill.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+defineProps<{
+  tier: 'gold' | 'silver' | 'bronze' | 'special';
+}>();
+
+const tierClass: Record<string, string> = {
+  gold: 'bg-yellow-100 text-yellow-800',
+  silver: 'bg-gray-200 text-gray-800',
+  bronze: 'bg-orange-100 text-orange-800',
+  special: 'bg-green-100 text-green-800',
+};
+</script>
+
+<template>
+  <span
+    class="inline-block px-2 py-0.5 rounded-full text-xs font-semibold uppercase tracking-wide"
+    :class="tierClass[tier]"
+  >
+    {{ tier }}
+  </span>
+</template>

--- a/components/badge/BadgesTable.vue
+++ b/components/badge/BadgesTable.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import type { BadgeCatalogItem } from '~/types';
+import BadgeTierPill from './BadgeTierPill.vue';
+
+defineProps<{
+  badges: BadgeCatalogItem[];
+  selectedCode: string | null;
+}>();
+
+const emit = defineEmits<{
+  (e: 'select', code: string): void;
+}>();
+</script>
+
+<template>
+  <div class="overflow-hidden rounded-lg border border-gray-200">
+    <div class="grid grid-cols-12 bg-gray-50 px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+      <div class="col-span-3">
+        Badge
+      </div>
+      <div class="col-span-2">
+        Tier
+      </div>
+      <div class="col-span-5">
+        Criteria
+      </div>
+      <div class="col-span-2 text-right">
+        Earned by
+      </div>
+    </div>
+    <div class="divide-y divide-gray-200 bg-white">
+      <button
+        v-for="b in badges"
+        :key="b.code"
+        type="button"
+        class="grid grid-cols-12 items-center w-full px-4 py-3 text-left hover:bg-gray-50 transition-colors"
+        :class="{ 'bg-brandgreen bg-opacity-10': selectedCode === b.code }"
+        @click="emit('select', b.code)"
+      >
+        <div class="col-span-3">
+          <div class="text-sm font-medium text-gray-900">
+            {{ b.name }}
+          </div>
+          <div class="text-xs text-gray-500">
+            {{ b.code }}
+          </div>
+        </div>
+        <div class="col-span-2">
+          <BadgeTierPill :tier="b.tier" />
+        </div>
+        <div class="col-span-5 text-sm text-gray-600">
+          {{ b.criteria_summary }}
+        </div>
+        <div class="col-span-2 text-right text-sm font-semibold text-gray-900">
+          {{ b.earned_by_count }}
+        </div>
+      </button>
+    </div>
+  </div>
+</template>

--- a/components/badge/RecomputeLeaderboardsButton.vue
+++ b/components/badge/RecomputeLeaderboardsButton.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import DefaultButton from '~/components/common/DefaultButton.vue';
+import TextInput from '~/components/common/TextInput.vue';
+import badgesApi from '~/api/badges';
+import { useToast } from '~/components/ui/toast/use-toast';
+
+const emit = defineEmits<{ (e: 'done'): void }>();
+
+const { toast } = useToast();
+const isOpen = ref(false);
+const yearInput = ref(String(new Date().getFullYear() - 1));
+const isSubmitting = ref(false);
+
+const submit = async () => {
+  const year = Number.parseInt(yearInput.value, 10);
+  if (!Number.isFinite(year) || year < 2010 || year > 2100) {
+    toast({ variant: 'destructive', title: 'Enter a valid year' });
+    return;
+  }
+  isSubmitting.value = true;
+  try {
+    const res = await badgesApi.recomputeLeaderboards(year);
+    toast({
+      title: `Recomputed ${res.year}`,
+      description: `${res.awarded} Local Legend badges awarded.`,
+    });
+    isOpen.value = false;
+    emit('done');
+  } catch {
+    toast({ variant: 'destructive', title: 'Recompute failed' });
+  } finally {
+    isSubmitting.value = false;
+  }
+};
+</script>
+
+<template>
+  <DefaultButton
+    type="inactive"
+    size="small"
+    @click="isOpen = true"
+  >
+    Recompute leaderboards
+  </DefaultButton>
+  <div
+    v-if="isOpen"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+    @click.self="isOpen = false"
+  >
+    <div class="bg-white rounded-md shadow-2xl border border-bluegray p-6 w-[360px]">
+      <h3 class="text-lg font-semibold mb-1">
+        Recompute Local Legend
+      </h3>
+      <p class="text-sm text-gray-600 mb-4">
+        Awards the yearly winner per city for the target year. Safe to re-run.
+      </p>
+      <label class="text-xs uppercase tracking-wide text-gray-500">
+        Year
+      </label>
+      <TextInput
+        v-model="yearInput"
+        placeholder="2024"
+        class="w-full my-2"
+      />
+      <div class="flex justify-end gap-2 mt-4">
+        <DefaultButton
+          type="inactive"
+          size="small"
+          :disabled="isSubmitting"
+          @click="isOpen = false"
+        >
+          Cancel
+        </DefaultButton>
+        <DefaultButton
+          size="small"
+          :disabled="isSubmitting"
+          @click="submit"
+        >
+          {{ isSubmitting ? 'Running…' : 'Run' }}
+        </DefaultButton>
+      </div>
+    </div>
+  </div>
+</template>

--- a/components/common/DefaultHeader.vue
+++ b/components/common/DefaultHeader.vue
@@ -18,6 +18,10 @@ const links = [
         label: "Events",
         link: "/events",
     },
+    {
+        label: "Badges",
+        link: "/badges",
+    },
 ];
 
 const logout = () => {

--- a/pages/badges/index.vue
+++ b/pages/badges/index.vue
@@ -1,0 +1,107 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import BadgeAwardsPanel from '~/components/badge/BadgeAwardsPanel.vue';
+import BadgesTable from '~/components/badge/BadgesTable.vue';
+import RecomputeLeaderboardsButton from '~/components/badge/RecomputeLeaderboardsButton.vue';
+import InstructionParagraph from '~/components/common/InstructionParagraph.vue';
+import LoadingContent from '~/components/common/LoadingContent.vue';
+import badgesApi from '~/api/badges';
+import { useToast } from '~/components/ui/toast/use-toast';
+import type { BadgeCatalogItem } from '~/types';
+
+const { toast } = useToast();
+const badges = ref<BadgeCatalogItem[]>([]);
+const isLoading = ref(true);
+const selectedCode = ref<string | null>(null);
+
+const load = async () => {
+  isLoading.value = true;
+  try {
+    badges.value = await badgesApi.listBadges();
+  } catch {
+    toast({ variant: 'destructive', title: 'Failed to load badges' });
+  } finally {
+    isLoading.value = false;
+  }
+};
+
+onMounted(load);
+
+const localLegendBadge = computed(() =>
+  badges.value.find((b) => b.code === 'local_legend'),
+);
+</script>
+
+<template>
+  <div class="grid grid-cols-3 px-[36px] gap-[80px]">
+    <div class="col-span-2">
+      <div class="flex justify-between items-center mb-6">
+        <h2>Badges</h2>
+        <div class="flex items-center gap-3">
+          <RecomputeLeaderboardsButton @done="load" />
+        </div>
+      </div>
+
+      <LoadingContent :is-loading="isLoading">
+        <div class="grid grid-cols-12 gap-4">
+          <div :class="selectedCode ? 'col-span-7' : 'col-span-12'">
+            <BadgesTable
+              :badges="badges"
+              :selected-code="selectedCode"
+              @select="(code) => (selectedCode = code)"
+            />
+          </div>
+          <div
+            v-if="selectedCode"
+            class="col-span-5"
+          >
+            <BadgeAwardsPanel
+              :code="selectedCode"
+              @revoked="load"
+              @close="selectedCode = null"
+            />
+          </div>
+        </div>
+      </LoadingContent>
+    </div>
+
+    <InstructionParagraph class="col-span-1 mt-[54px]">
+      <template #title>
+        Badges Management
+      </template>
+      <template #text>
+        <div class="space-y-4">
+          <div>
+            <h4 class="font-medium text-gray-900">
+              Catalog
+            </h4>
+            <p class="text-sm text-gray-600">
+              Every badge in the system with its tier, criteria, and how
+              many users have earned it. Click a row to see who holds it.
+            </p>
+          </div>
+          <div>
+            <h4 class="font-medium text-gray-900">
+              Manual award / revoke
+            </h4>
+            <p class="text-sm text-gray-600">
+              Open Source Contributor and Suggestion Box are admin-awarded.
+              From the Users page you can award any badge to a specific user.
+              Revoke from the side panel here.
+            </p>
+          </div>
+          <div v-if="localLegendBadge">
+            <h4 class="font-medium text-gray-900">
+              Local Legend
+            </h4>
+            <p class="text-sm text-gray-600">
+              Awarded yearly to the top attendee per city. Runs Jan 2 via
+              cron; use "Recompute leaderboards" to backfill any year on
+              demand.
+            </p>
+          </div>
+        </div>
+      </template>
+    </InstructionParagraph>
+  </div>
+</template>

--- a/pages/users/[id].vue
+++ b/pages/users/[id].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ArrowTopRightOnSquareIcon } from "@heroicons/vue/24/solid";
+import AwardBadgeButton from "~/components/badge/AwardBadgeButton.vue";
 import DefaultButton from "~/components/common/DefaultButton.vue";
 import EntityHeader from "~/components/common/EntityHeader.vue";
 import EntityParagraph from "~/components/common/EntityParagraph.vue";
@@ -99,6 +100,10 @@ const openTelegram = (username: string) => {
               >
                 Unban User
               </DefaultButton>
+              <AwardBadgeButton
+                :alumni-id="user.id"
+                :user-label="`${user.first_name} ${user.last_name}`"
+              />
             </div>
           </template>
         </EntityHeader>

--- a/types/index.ts
+++ b/types/index.ts
@@ -114,3 +114,32 @@ export type Paginated<T> = {
     items: T[];
     next_cursor: string | null;
 };
+
+// ─── Badges ────────────────────────────────────────────────────────────────
+
+export type BadgeCatalogItem = {
+    code: string;
+    name: string;
+    description: string;
+    tier: 'gold' | 'silver' | 'bronze' | 'special';
+    icon_key: string;
+    strategy: string;
+    criteria_summary: string;
+    earned_by_count: number;
+};
+
+export type BadgeAward = {
+    alumni_id: string;
+    first_name: string;
+    last_name: string;
+    email: string;
+    awarded_at: string | null;
+    awarded_by: string | null;
+    extra: Record<string, unknown>;
+};
+
+export type BadgeAwardsResponse = {
+    code: string;
+    name: string;
+    awards: BadgeAward[];
+};


### PR DESCRIPTION
## Summary
New admin surface for the badges catalog and manual award / revoke flows.

- **\`pages/badges\`** — catalog table on the left with tier pill, criteria summary, and earned-by count. Click a row → side panel listing every holder of that badge (per-instance, so Local Legend / Founding Host show up once per city+year / city). Each row has a Revoke button.
- **Recompute Local Legend** button opens a small year picker → \`POST /admin/badges/recompute-leaderboards\`. Toast reports how many winners landed. Safe for backfill.
- **Award Badge** button on the user detail page opens a badge picker → \`POST /admin/badges/award\` for that user. Idempotency errors from the backend surface as a destructive toast with the server's message.
- Header gets a **Badges** tab.

Types + api client added. Consumes the admin endpoints landed on the backend chain (award/revoke #124, recompute #125, listing #126).

## Depends on (backend)
Merge these first:
1. [iu-alumni-backend#124](https://github.com/iu-alumni/iu-alumni-backend/pull/124) — manual award/revoke
2. [iu-alumni-backend#125](https://github.com/iu-alumni/iu-alumni-backend/pull/125) — Local Legend cron
3. [iu-alumni-backend#126](https://github.com/iu-alumni/iu-alumni-backend/pull/126) — admin listing endpoints

## Closes
Closes iu-alumni/iu-alumni-frontend#72.

## Test plan
- [x] eslint clean on all new files.
- [x] \`nuxi typecheck\` — no errors from new files (pre-existing errors on \`main\` remain).
- [x] \`npm run dev\` → /badges renders the catalog with counts, side panel opens on click.
- [x] Revoke a Networker from a test user → toast, panel refreshes, catalog count decrements.
- [x] Recompute leaderboards for 2024 → toast confirms N awarded.
- [x] /users/{id} → Award Badge → pick Suggestion Box → toast, user sees the badge on next mobile-app load.