### PR TITLE
feat(projects): admin portal /projects page [#10]

### DIFF
--- a/api/projects.ts
+++ b/api/projects.ts
@@ -1,0 +1,59 @@
+import type {
+    Paginated,
+    Project,
+    ProjectListItem,
+    ProjectStatusFilter,
+} from "~/types";
+import axiosInstance from ".";
+
+interface AdminListParams {
+    status?: ProjectStatusFilter;
+    search?: string;
+    cursor?: string;
+    limit?: number;
+}
+
+function adminListProjects (params?: AdminListParams): Promise<Paginated<ProjectListItem>> {
+    return axiosInstance
+        .get("api/v1/admin/projects", { params })
+        .then((r) => r.data);
+}
+
+function getProjectCover (projectId: string): Promise<{ cover: string | null }> {
+    return axiosInstance
+        .get(`api/v1/projects/${projectId}/cover`)
+        .then((r) => r.data);
+}
+
+function approveProject (projectId: string): Promise<Project> {
+    return axiosInstance
+        .post(`api/v1/admin/projects/approve/${projectId}`)
+        .then((r) => r.data);
+}
+
+function declineProject (projectId: string): Promise<Project> {
+    return axiosInstance
+        .post(`api/v1/admin/projects/decline/${projectId}`)
+        .then((r) => r.data);
+}
+
+function unapproveProject (projectId: string): Promise<Project> {
+    return axiosInstance
+        .post(`api/v1/admin/projects/unapprove/${projectId}`)
+        .then((r) => r.data);
+}
+
+function deleteProject (projectId: string): Promise<unknown> {
+    return axiosInstance
+        .delete(`api/v1/projects/${projectId}`)
+        .then((r) => r.data);
+}
+
+export default {
+    adminListProjects,
+    getProjectCover,
+    approveProject,
+    declineProject,
+    unapproveProject,
+    deleteProject,
+};

--- a/components/common/DefaultHeader.vue
+++ b/components/common/DefaultHeader.vue
@@ -22,6 +22,10 @@ const links = [
         label: "Badges",
         link: "/badges",
     },
+    {
+        label: "Projects",
+        link: "/projects",
+    },
 ];
 
 const logout = () => {

--- a/components/project/ProjectDetailModal.vue
+++ b/components/project/ProjectDetailModal.vue
@@ -1,0 +1,174 @@
+<script setup lang="ts">
+import DefaultButton from "~/components/common/DefaultButton.vue";
+import type { ProjectListItem } from "~/types";
+
+const props = defineProps<{
+    project: ProjectListItem | null;
+}>();
+
+const emit = defineEmits(["close", "approve", "decline", "unapprove"]);
+
+const formatDate = (iso: string) =>
+    new Intl.DateTimeFormat("en-US", {
+        year: "numeric",
+        month: "short",
+        day: "2-digit",
+    }).format(new Date(iso));
+
+const statusLabel = (approved: boolean | null) => {
+    if (approved === true) return "Approved";
+    if (approved === false) return "Declined";
+    return "Pending review";
+};
+</script>
+
+<template>
+  <Teleport to="body">
+    <transition name="fade">
+      <div
+        v-if="project"
+        class="fixed inset-0 z-40 bg-black/40"
+        @click="emit('close')"
+      />
+    </transition>
+    <transition name="slide">
+      <aside
+        v-if="project"
+        class="fixed inset-y-0 right-0 z-50 flex w-full max-w-md flex-col bg-white shadow-xl"
+      >
+        <header class="flex items-start justify-between border-b border-gray-100 p-6">
+          <div class="min-w-0">
+            <p class="text-xs uppercase tracking-wider text-gray-400">
+              {{ statusLabel(project.approved) }}
+            </p>
+            <h3 class="mt-1 truncate text-lg font-semibold text-gray-900">
+              {{ project.title }}
+            </h3>
+          </div>
+          <button
+            type="button"
+            class="ml-4 text-gray-400 hover:text-gray-600"
+            @click="emit('close')"
+          >
+            ✕
+          </button>
+        </header>
+
+        <div class="flex-1 overflow-y-auto p-6 space-y-6">
+          <img
+            v-if="project.cover"
+            :src="`data:image/jpeg;base64,${project.cover}`"
+            :alt="project.title"
+            class="w-full rounded-lg object-cover"
+            style="max-height: 220px;"
+          >
+
+          <div>
+            <p class="text-xs uppercase tracking-wider text-gray-400 mb-1">
+              Description
+            </p>
+            <p class="whitespace-pre-wrap text-sm text-gray-700 leading-relaxed">
+              {{ project.description }}
+            </p>
+          </div>
+
+          <div class="grid grid-cols-2 gap-4">
+            <div>
+              <p class="text-xs uppercase tracking-wider text-gray-400 mb-1">
+                Contributors
+              </p>
+              <p class="text-sm text-gray-900">
+                {{ project.contributors_ids.length }}
+              </p>
+            </div>
+            <div>
+              <p class="text-xs uppercase tracking-wider text-gray-400 mb-1">
+                Created
+              </p>
+              <p class="text-sm text-gray-900">
+                {{ formatDate(project.created_at) }}
+              </p>
+            </div>
+          </div>
+
+          <div>
+            <p class="text-xs uppercase tracking-wider text-gray-400 mb-1">
+              Owner ID
+            </p>
+            <p class="break-all text-xs text-gray-600 font-mono">
+              {{ project.owner_id }}
+            </p>
+          </div>
+        </div>
+
+        <footer class="border-t border-gray-100 p-4 flex flex-wrap gap-2 justify-end">
+          <template v-if="project.approved === null">
+            <DefaultButton
+              type="inactive"
+              size="small"
+              @click="emit('decline', project.id)"
+            >
+              Decline
+            </DefaultButton>
+            <DefaultButton
+              size="small"
+              @click="emit('approve', project.id)"
+            >
+              Approve
+            </DefaultButton>
+          </template>
+          <template v-else-if="project.approved === true">
+            <DefaultButton
+              type="inactive"
+              size="small"
+              @click="emit('unapprove', project.id)"
+            >
+              Send back to review
+            </DefaultButton>
+            <DefaultButton
+              type="error"
+              size="small"
+              @click="emit('decline', project.id)"
+            >
+              Decline
+            </DefaultButton>
+          </template>
+          <template v-else>
+            <DefaultButton
+              type="inactive"
+              size="small"
+              @click="emit('unapprove', project.id)"
+            >
+              Reopen for review
+            </DefaultButton>
+            <DefaultButton
+              size="small"
+              @click="emit('approve', project.id)"
+            >
+              Approve
+            </DefaultButton>
+          </template>
+        </footer>
+      </aside>
+    </transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+    transition: opacity 0.2s ease;
+}
+.fade-enter-from,
+.fade-leave-to {
+    opacity: 0;
+}
+.slide-enter-active,
+.slide-leave-active {
+    transition: transform 0.25s ease;
+}
+.slide-enter-from,
+.slide-leave-to {
+    transform: translateX(100%);
+}
+</style>

--- a/components/project/ProjectDetailModal.vue
+++ b/components/project/ProjectDetailModal.vue
@@ -91,6 +91,20 @@ const statusLabel = (approved: boolean | null) => {
             </div>
           </div>
 
+          <div v-if="project.donation_link">
+            <p class="text-xs uppercase tracking-wider text-gray-400 mb-1">
+              Donation link
+            </p>
+            <a
+              :href="project.donation_link"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="break-all text-sm text-blue-600 hover:underline"
+            >
+              {{ project.donation_link }}
+            </a>
+          </div>
+
           <div>
             <p class="text-xs uppercase tracking-wider text-gray-400 mb-1">
               Owner ID

--- a/components/project/ProjectDetailModal.vue
+++ b/components/project/ProjectDetailModal.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import DefaultButton from "~/components/common/DefaultButton.vue";
 import type { ProjectListItem } from "~/types";
 
@@ -20,6 +21,25 @@ const statusLabel = (approved: boolean | null) => {
     if (approved === false) return "Declined";
     return "Pending review";
 };
+
+// Compact ruble format matching the mobile card: 720k / 1M / 1.2k / 500.
+const formatRubles = (amount: number) => {
+    if (amount >= 1_000_000) {
+        const m = amount / 1_000_000;
+        return m === Math.round(m) ? `${m}M` : `${m.toFixed(1)}M`;
+    }
+    if (amount >= 1_000) {
+        const k = amount / 1_000;
+        return k === Math.round(k) ? `${k}k` : `${k.toFixed(1)}k`;
+    }
+    return String(amount);
+};
+
+const progressPct = computed(() => {
+    const p = props.project;
+    if (!p || !p.goal_amount || p.goal_amount <= 0) return 0;
+    return Math.min(100, Math.round((p.raised_amount / p.goal_amount) * 100));
+});
 </script>
 
 <template>
@@ -88,6 +108,26 @@ const statusLabel = (approved: boolean | null) => {
               <p class="text-sm text-gray-900">
                 {{ formatDate(project.created_at) }}
               </p>
+            </div>
+          </div>
+
+          <div v-if="project.goal_amount">
+            <p class="text-xs uppercase tracking-wider text-gray-400 mb-1">
+              Fundraising
+            </p>
+            <div class="mt-1 h-2.5 w-full overflow-hidden rounded-full bg-gray-100">
+              <div
+                class="h-full rounded-full bg-emerald-500"
+                :style="{ width: progressPct + '%' }"
+              />
+            </div>
+            <div class="mt-1.5 flex items-baseline justify-between text-sm">
+              <span class="font-bold text-emerald-700">
+                &#8381; {{ formatRubles(project.raised_amount) }} raised
+              </span>
+              <span class="text-gray-500">
+                of &#8381; {{ formatRubles(project.goal_amount) }} &middot; {{ progressPct }}%
+              </span>
             </div>
           </div>
 

--- a/components/project/ProjectTable.vue
+++ b/components/project/ProjectTable.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+import Approve from "@/assets/icons/misc/button__approve.svg";
+import Reject from "@/assets/icons/misc/button__reject.svg";
+import type { ProjectListItem } from "~/types";
+import SmallIcon from "../common/SmallIcon.vue";
+
+defineProps<{
+    projects: ProjectListItem[];
+}>();
+
+const emit = defineEmits(["approve", "reject", "open"]);
+
+const getStatusBadge = (project: ProjectListItem) => {
+    if (project.approved === true) return { text: "Approved", class: "bg-green-100 text-green-800" };
+    if (project.approved === false) return { text: "Declined", class: "bg-red-100 text-red-800" };
+    return { text: "Pending", class: "bg-yellow-100 text-yellow-800" };
+};
+
+const formatDate = (iso: string) =>
+    new Intl.DateTimeFormat("en-US", {
+        year: "numeric",
+        month: "short",
+        day: "2-digit",
+    }).format(new Date(iso));
+</script>
+
+<template>
+  <div class="overflow-hidden rounded-lg border border-gray-200">
+    <!-- Header -->
+    <div
+      class="grid grid-cols-12 bg-gray-50 px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+    >
+      <div class="col-span-5">
+        Project
+      </div>
+      <div class="col-span-2">
+        Contributors
+      </div>
+      <div class="col-span-2">
+        Created
+      </div>
+      <div class="col-span-2">
+        Status
+      </div>
+      <div class="col-span-1 text-right">
+        Actions
+      </div>
+    </div>
+
+    <!-- Rows -->
+    <div class="divide-y divide-gray-200">
+      <div
+        v-for="project in projects"
+        :key="project.id"
+        class="cursor-pointer bg-white hover:bg-gray-50"
+        @click="emit('open', project.id)"
+      >
+        <div class="grid grid-cols-12 items-center px-4 py-4">
+          <!-- Cover + title -->
+          <div class="col-span-5 flex items-center space-x-3">
+            <img
+              v-if="project.cover"
+              :src="`data:image/jpeg;base64,${project.cover}`"
+              class="h-10 w-10 flex-shrink-0 rounded-lg object-cover"
+              :alt="project.title"
+            >
+            <div
+              v-else
+              class="h-10 w-10 flex-shrink-0 rounded-lg bg-gray-200"
+            />
+            <div class="min-w-0">
+              <div class="truncate text-sm font-medium text-gray-900">
+                {{ project.title }}
+              </div>
+              <div class="truncate text-xs text-gray-500">
+                {{ project.description }}
+              </div>
+            </div>
+          </div>
+
+          <!-- Contributors -->
+          <div class="col-span-2 text-sm text-gray-500">
+            {{ project.contributors_ids.length }}
+          </div>
+
+          <!-- Created -->
+          <div class="col-span-2 text-sm text-gray-500">
+            {{ formatDate(project.created_at) }}
+          </div>
+
+          <!-- Status -->
+          <div class="col-span-2">
+            <span
+              class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium"
+              :class="getStatusBadge(project).class"
+            >
+              {{ getStatusBadge(project).text }}
+            </span>
+          </div>
+
+          <!-- Actions (only when pending) -->
+          <div
+            class="col-span-1 flex justify-end space-x-2"
+            @click.stop
+          >
+            <template v-if="project.approved === null">
+              <button
+                type="button"
+                class="text-green-400 hover:text-green-500"
+                @click="emit('approve', project.id)"
+              >
+                <SmallIcon :src="Approve" />
+              </button>
+              <button
+                type="button"
+                class="text-red-400 hover:text-red-500"
+                @click="emit('reject', project.id)"
+              >
+                <SmallIcon :src="Reject" />
+              </button>
+            </template>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Empty -->
+    <div
+      v-if="projects.length === 0"
+      class="px-4 py-12 text-center"
+    >
+      <p class="text-sm text-gray-500">
+        No projects found
+      </p>
+    </div>
+  </div>
+</template>

--- a/components/project/ProjectTable.vue
+++ b/components/project/ProjectTable.vue
@@ -79,8 +79,15 @@ const formatDate = (iso: string) =>
           </div>
 
           <!-- Contributors -->
-          <div class="col-span-2 text-sm text-gray-500">
-            {{ project.contributors_ids.length }}
+          <div class="col-span-2 text-sm text-gray-500 flex items-center gap-2">
+            <span>{{ project.contributors_ids.length }}</span>
+            <span
+              v-if="project.donation_link"
+              class="inline-flex items-center rounded-full bg-blue-50 px-2 py-0.5 text-[10px] font-semibold text-blue-700"
+              title="Has donation link"
+            >
+              💳 Link
+            </span>
           </div>
 
           <!-- Created -->

--- a/components/project/ProjectTable.vue
+++ b/components/project/ProjectTable.vue
@@ -22,6 +22,11 @@ const formatDate = (iso: string) =>
         month: "short",
         day: "2-digit",
     }).format(new Date(iso));
+
+const pctFor = (p: ProjectListItem) => {
+    if (!p.goal_amount || p.goal_amount <= 0) return 0;
+    return Math.min(100, Math.round((p.raised_amount / p.goal_amount) * 100));
+};
 </script>
 
 <template>
@@ -78,8 +83,8 @@ const formatDate = (iso: string) =>
             </div>
           </div>
 
-          <!-- Contributors -->
-          <div class="col-span-2 text-sm text-gray-500 flex items-center gap-2">
+          <!-- Contributors + fundraising signal -->
+          <div class="col-span-2 text-sm text-gray-500 flex items-center gap-2 flex-wrap">
             <span>{{ project.contributors_ids.length }}</span>
             <span
               v-if="project.donation_link"
@@ -87,6 +92,13 @@ const formatDate = (iso: string) =>
               title="Has donation link"
             >
               💳 Link
+            </span>
+            <span
+              v-if="project.goal_amount"
+              class="inline-flex items-center rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-semibold text-emerald-700"
+              :title="`Raised ₽${project.raised_amount} of ₽${project.goal_amount}`"
+            >
+              {{ pctFor(project) }}%
             </span>
           </div>
 

--- a/pages/projects/index.vue
+++ b/pages/projects/index.vue
@@ -1,0 +1,184 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from "vue";
+import DefaultButton from "~/components/common/DefaultButton.vue";
+import InstructionParagraph from "~/components/common/InstructionParagraph.vue";
+import LoadingContent from "~/components/common/LoadingContent.vue";
+import TextInput from "~/components/common/TextInput.vue";
+import ProjectDetailModal from "~/components/project/ProjectDetailModal.vue";
+import ProjectTable from "~/components/project/ProjectTable.vue";
+import { useProjectsStore } from "~/store/projects";
+import type { ProjectListItem, ProjectStatusFilter } from "~/types";
+
+const projectsStore = useProjectsStore();
+
+const isLoading = ref(true);
+const search = ref(projectsStore.search);
+const selectedId = ref<string | null>(null);
+
+const filters: { label: string; value: ProjectStatusFilter }[] = [
+    { label: "Pending", value: "pending" },
+    { label: "Approved", value: "approved" },
+    { label: "Declined", value: "declined" },
+    { label: "All", value: "all" },
+];
+
+const activeFilter = computed(() => projectsStore.status);
+
+onMounted(async () => {
+    projectsStore.setStatus("pending");
+    await projectsStore.fetchProjects();
+    isLoading.value = false;
+});
+
+let searchTimeout: ReturnType<typeof setTimeout> | null = null;
+watch(search, (value) => {
+    if (searchTimeout) clearTimeout(searchTimeout);
+    searchTimeout = setTimeout(async () => {
+        projectsStore.setSearch(value);
+        await projectsStore.fetchProjects();
+    }, 300);
+});
+
+const setFilter = async (status: ProjectStatusFilter) => {
+    projectsStore.setStatus(status);
+    isLoading.value = true;
+    await projectsStore.fetchProjects();
+    isLoading.value = false;
+};
+
+const selected = computed<ProjectListItem | null>(() => {
+    if (!selectedId.value) return null;
+    return (
+        projectsStore.projects.find((p) => p.id === selectedId.value) ?? null
+    );
+});
+
+const open = (id: string) => {
+    selectedId.value = id;
+};
+
+const closeModal = () => {
+    selectedId.value = null;
+};
+
+const approve = async (id: string) => {
+    await projectsStore.approve(id);
+    selectedId.value = null;
+};
+const decline = async (id: string) => {
+    await projectsStore.decline(id);
+    selectedId.value = null;
+};
+const unapprove = async (id: string) => {
+    await projectsStore.unapprove(id);
+    selectedId.value = null;
+};
+
+const loadMore = async () => {
+    await projectsStore.loadMore();
+};
+</script>
+
+<template>
+  <div class="grid grid-cols-3 px-[36px] gap-[80px]">
+    <div class="col-span-2">
+      <div class="flex justify-between gap-[24px]">
+        <h2>Projects</h2>
+        <div class="flex gap-[24px]">
+          <TextInput
+            v-model="search"
+            class="max-w-[244px]"
+            placeholder="Search..."
+          />
+        </div>
+      </div>
+
+      <div class="mt-[24px] flex flex-wrap gap-2">
+        <button
+          v-for="f in filters"
+          :key="f.value"
+          type="button"
+          class="rounded-full px-4 py-1 text-sm font-medium transition-colors"
+          :class="[
+            activeFilter === f.value
+              ? 'bg-primary text-white'
+              : 'bg-gray-100 text-gray-600 hover:bg-gray-200',
+          ]"
+          @click="setFilter(f.value)"
+        >
+          {{ f.label }}
+        </button>
+      </div>
+
+      <LoadingContent :is-loading="isLoading">
+        <ProjectTable
+          class="mt-[24px]"
+          :projects="projectsStore.projects"
+          @approve="approve"
+          @reject="decline"
+          @open="open"
+        />
+        <div
+          v-if="projectsStore.nextCursor"
+          class="mt-4 flex justify-center"
+        >
+          <DefaultButton
+            size="small"
+            type="inactive"
+            @click="loadMore"
+          >
+            Load more
+          </DefaultButton>
+        </div>
+      </LoadingContent>
+    </div>
+
+    <InstructionParagraph class="col-span-1 mt-[54px]">
+      <template #title>
+        Projects Management Guide
+      </template>
+      <template #text>
+        <div class="space-y-4">
+          <div>
+            <h4 class="font-medium text-gray-900">
+              Filtering
+            </h4>
+            <p class="text-sm text-gray-600">
+              Use the pills above the table to switch between Pending,
+              Approved, Declined, or All projects. Pending is where new
+              alumnus submissions land.
+            </p>
+          </div>
+          <div>
+            <h4 class="font-medium text-gray-900">
+              Approving
+            </h4>
+            <p class="text-sm text-gray-600">
+              Click a row to open the detail panel and read the full
+              description. Green check publishes the project (visible to
+              all alumni). Red cross declines it.
+            </p>
+          </div>
+          <div>
+            <h4 class="font-medium text-gray-900">
+              Post-decision
+            </h4>
+            <p class="text-sm text-gray-600">
+              Already-decided projects can be sent back to review or
+              re-approved from the detail panel — useful when the owner
+              edits an approved project (which auto-resets it to pending).
+            </p>
+          </div>
+        </div>
+      </template>
+    </InstructionParagraph>
+
+    <ProjectDetailModal
+      :project="selected"
+      @close="closeModal"
+      @approve="approve"
+      @decline="decline"
+      @unapprove="unapprove"
+    />
+  </div>
+</template>

--- a/store/projects.ts
+++ b/store/projects.ts
@@ -1,0 +1,81 @@
+import { defineStore } from "pinia";
+import projectsInstance from "~/api/projects";
+import type { ProjectListItem, ProjectStatusFilter } from "~/types";
+
+interface ListParams {
+    status?: ProjectStatusFilter;
+    search?: string;
+    cursor?: string;
+    limit?: number;
+}
+
+export const useProjectsStore = defineStore("projects", {
+    state: () => ({
+        projects: [] as ProjectListItem[],
+        nextCursor: null as string | null,
+        status: "all" as ProjectStatusFilter,
+        search: "" as string,
+    }),
+
+    getters: {
+        getProjectById: (state) => (projectId: string) =>
+            state.projects.find((p) => p.id === projectId),
+    },
+
+    actions: {
+        async fetchProjects (params?: ListParams) {
+            const effective = {
+                status: params?.status ?? this.status,
+                search:
+                    (params?.search === undefined
+                        ? this.search
+                        : params.search) || undefined,
+                cursor: params?.cursor,
+                limit: params?.limit ?? 50,
+            };
+            const page = await projectsInstance.adminListProjects(effective);
+            this.projects = page.items;
+            this.nextCursor = page.next_cursor;
+        },
+
+        async loadMore () {
+            if (!this.nextCursor) return;
+            const page = await projectsInstance.adminListProjects({
+                status: this.status,
+                search: this.search || undefined,
+                cursor: this.nextCursor,
+            });
+            this.projects = [...this.projects, ...page.items];
+            this.nextCursor = page.next_cursor;
+        },
+
+        setStatus (status: ProjectStatusFilter) {
+            this.status = status;
+        },
+
+        setSearch (search: string) {
+            this.search = search;
+        },
+
+        async approve (projectId: string) {
+            await projectsInstance.approveProject(projectId);
+            await this.fetchProjects();
+        },
+
+        async decline (projectId: string) {
+            await projectsInstance.declineProject(projectId);
+            await this.fetchProjects();
+        },
+
+        async unapprove (projectId: string) {
+            await projectsInstance.unapproveProject(projectId);
+            await this.fetchProjects();
+        },
+
+        async remove (projectId: string) {
+            await projectsInstance.deleteProject(projectId);
+            const idx = this.projects.findIndex((p) => p.id === projectId);
+            if (idx !== -1) this.projects.splice(idx, 1);
+        },
+    },
+});

--- a/types/index.ts
+++ b/types/index.ts
@@ -155,6 +155,7 @@ export type Project = {
     title: string;
     description: string;
     cover: string | null;
+    donation_link: string | null;
     approved: boolean | null;
     created_at: string;
 };

--- a/types/index.ts
+++ b/types/index.ts
@@ -156,6 +156,10 @@ export type Project = {
     description: string;
     cover: string | null;
     donation_link: string | null;
+    /** Whole-ruble fundraising target the owner set. Null = no target. */
+    goal_amount: number | null;
+    /** Whole rubles raised so far (self-reported by donors). */
+    raised_amount: number;
     approved: boolean | null;
     created_at: string;
 };

--- a/types/index.ts
+++ b/types/index.ts
@@ -143,3 +143,22 @@ export type BadgeAwardsResponse = {
     name: string;
     awards: BadgeAward[];
 };
+
+/**
+ * Project — an alumnus-proposed cause / campaign that other alumni
+ * "contribute" to (v1 is a click, no money — see FR24 in docs).
+ */
+export type Project = {
+    id: string;
+    owner_id: string;
+    contributors_ids: string[];
+    title: string;
+    description: string;
+    cover: string | null;
+    approved: boolean | null;
+    created_at: string;
+};
+
+export type ProjectListItem = Project;
+
+export type ProjectStatusFilter = "pending" | "approved" | "declined" | "all";


### PR DESCRIPTION
## Summary
New surface in the admin portal for triaging alumni-proposed projects. Consumes the admin endpoints landed in iu-alumni/iu-alumni-backend#132.

- **`pages/projects/index.vue`** — table + filter pills (Pending / Approved / Declined / All), search bar with the standard 300 ms debounce, approve/decline actions per pending row, click-to-open detail panel, cursor-based Load more.
- **`components/project/ProjectTable.vue`** — row per project (cover thumb, title + description snippet, contributor count, created date, status badge, quick actions). Row click emits \`open\` for the modal.
- **`components/project/ProjectDetailModal.vue`** — right-side slide-in with the full description, cover, contributor count, and **state-aware** action buttons (Approve/Decline when pending; Send-back / Decline when approved; Reopen / Approve when declined).
- **`api/projects.ts`** — axios client for admin/projects list + approve/decline/unapprove + the public delete + the cover blob.
- **`store/projects.ts`** — Pinia store: status + search state, cursor pagination, approve/decline/unapprove/remove actions that refetch on success.
- **`types/index.ts`** — \`Project\`, \`ProjectListItem\`, \`ProjectStatusFilter\`.
- **`components/common/DefaultHeader.vue`** — Projects tab wedged after Events.

## Closes
Closes iu-alumni/iu-alumni-frontend#76.

## Test plan
- [x] eslint clean on all new / modified files.
- [ ] Manual: log in as admin → /projects → new row is Pending → Approve → status flips → Send back to review → status returns to Pending.
- [ ] Manual: mobile creates a project (via [iu-alumni-mobile#148](https://github.com/iu-alumni/iu-alumni-mobile/pull/148)) → shows up on /projects with **Pending** → approve → visible in the mobile Projects tab.

---
Closes #78
