### PR TITLE
feat(alumni_friend): role chip + role editor in admin portal [#18]

### DIFF
--- a/api/users.ts
+++ b/api/users.ts
@@ -1,4 +1,4 @@
-import type { User, UserListItem, UserProfile, Paginated } from "~/types";
+import type { AlumniRole, User, UserListItem, UserProfile, Paginated } from "~/types";
 import axiosInstance from ".";
 
 interface ListUsersParams {
@@ -41,6 +41,14 @@ function unverifyUser (email: string): Promise<User> {
   return axiosInstance.post('api/v1/admin/unverify', { email }).then(req => req.data)
 }
 
+// Admin verify endpoint accepts an optional `role` field; sending only
+// the role flips it without re-triggering side-effects on already-
+// verified users. Backend clears graduation_year server-side when the
+// role becomes 'alumni_friend'.
+function setUserRole (email: string, role: AlumniRole): Promise<{ email: string; role: AlumniRole }> {
+  return axiosInstance.post('api/v1/admin/verify', { email, role }).then(req => req.data)
+}
+
 function uploadAllowedEmailsXls (file: File): Promise<{success: true, message: string}> {
   const formData = new FormData();
   formData.append("file", file);
@@ -63,5 +71,6 @@ export default {
   unbanUser,
   verifyUser,
   unverifyUser,
+  setUserRole,
   uploadAllowedEmailsXls
 }

--- a/components/user/UserTable.vue
+++ b/components/user/UserTable.vue
@@ -204,9 +204,18 @@ const handleFilterChange = (
             <UserAvatar :user-id="user.id" />
             <div class="flex-1 min-w-0">
               <div class="flex justify-between items-start">
-                <h4 class="font-medium text-gray-900 truncate">
-                  {{ user.name }}
-                </h4>
+                <div class="flex items-center gap-2 min-w-0">
+                  <h4 class="font-medium text-gray-900 truncate">
+                    {{ user.name }}
+                  </h4>
+                  <span
+                    v-if="user.role === 'alumni_friend'"
+                    class="inline-flex items-center rounded-full bg-yellow-100 px-2 py-0.5 text-[10px] font-semibold text-yellow-800"
+                    title="Non-graduate community member"
+                  >
+                    Friend
+                  </span>
+                </div>
                 <div class="flex items-center gap-1">
                   <button
                     class="p-1 text-sm rounded-md"
@@ -285,11 +294,18 @@ const handleFilterChange = (
         <div
           class="hidden md:grid grid-cols-12 items-center p-4 hover:bg-gray-50 border-t"
         >
-          <div class="col-span-4 flex items-center gap-3">
+          <div class="col-span-4 flex items-center gap-3 min-w-0">
             <UserAvatar :user-id="user.id" />
             <span class="font-medium truncate">{{
               user.name
             }}</span>
+            <span
+              v-if="user.role === 'alumni_friend'"
+              class="inline-flex items-center rounded-full bg-yellow-100 px-2 py-0.5 text-[10px] font-semibold text-yellow-800 whitespace-nowrap"
+              title="Non-graduate community member"
+            >
+              Friend
+            </span>
           </div>
           <div class="col-span-3 text-gray-600 truncate">
             {{ user.email }}

--- a/pages/users/[id].vue
+++ b/pages/users/[id].vue
@@ -9,7 +9,7 @@ import EventTable from "~/components/event/EventTable.vue";
 import UserActivities from "~/components/user/UserActivities.vue";
 import UserStickers from "~/components/user/UserStickers.vue";
 import { useUsersStore } from "~/store/users";
-import type { UserProfile } from "~/types";
+import type { UserProfile, AlumniRole } from "~/types";
 
 const route = useRoute();
 const usersStore = useUsersStore();
@@ -17,6 +17,7 @@ const usersStore = useUsersStore();
 const user = ref<UserProfile>();
 const isLoading = ref(true);
 const isVerifying = ref(false);
+const isSavingRole = ref(false);
 
 onMounted(async () => {
     user.value = await usersStore.getUserById(route.params.id as string);
@@ -29,12 +30,34 @@ const ban = async () => {
     }
 };
 
-const formatGraduationYear = (year: string) => {
-    return `Class of ${year}`;
+const formatGraduationYear = (year: string | null) => {
+    return year ? `Class of ${year}` : "Alumni Friend — no graduation year";
 };
 
 const openTelegram = (username: string) => {
     window.open(`https://t.me/${username}`, "_blank");
+};
+
+// Flip the user's role via the admin verify endpoint. The endpoint
+// treats `role` as an override that also runs the verify flow, so we
+// only offer this to already-verified users to avoid re-sending the
+// "you're verified!" email. Admins that need to change role AND verify
+// use the Verify button instead.
+const changeRole = async (nextRole: AlumniRole) => {
+    if (!user.value || user.value.role === nextRole || isSavingRole.value) {
+        return;
+    }
+    isSavingRole.value = true;
+    try {
+        const updated = await usersStore.setUserRole(user.value.id, nextRole);
+        if (updated) {
+            user.value = updated;
+        }
+    } catch (err) {
+        console.error("Failed to change role:", err);
+    } finally {
+        isSavingRole.value = false;
+    }
 };
 </script>
 
@@ -63,9 +86,46 @@ const openTelegram = (username: string) => {
           </template>
           <template #subtitle>
             <div class="mt-1 space-y-1">
-              <p class="text-sm text-gray-600">
-                {{ formatGraduationYear(user.graduation_year) }}
-              </p>
+              <div class="flex flex-wrap items-center gap-2">
+                <p class="text-sm text-gray-600">
+                  {{ formatGraduationYear(user.graduation_year) }}
+                </p>
+                <span
+                  v-if="user.role === 'alumni_friend'"
+                  class="inline-flex items-center rounded-full bg-yellow-100 px-2 py-0.5 text-[10px] font-semibold text-yellow-800"
+                >
+                  Alumni Friend
+                </span>
+              </div>
+              <div class="flex items-center gap-2 text-sm">
+                <label
+                  for="role-select"
+                  class="text-gray-600"
+                >Role:</label>
+                <select
+                  id="role-select"
+                  :value="user.role"
+                  :disabled="isSavingRole"
+                  class="rounded-md border-gray-300 text-sm py-1"
+                  @change="
+                    changeRole(
+                      ($event.target as HTMLSelectElement)
+                        .value as AlumniRole,
+                    )
+                  "
+                >
+                  <option value="alumni">
+                    Alumni
+                  </option>
+                  <option value="alumni_friend">
+                    Alumni Friend
+                  </option>
+                </select>
+                <span
+                  v-if="isSavingRole"
+                  class="text-xs text-gray-500"
+                >Saving…</span>
+              </div>
               <p
                 v-if="user.show_location && user.location"
                 class="text-sm text-gray-600"

--- a/store/users.ts
+++ b/store/users.ts
@@ -103,6 +103,31 @@ export const useUsersStore = defineStore('users', {
       }
     },
 
+    /**
+     * Flip a user's role via the admin verify endpoint (which accepts
+     * an optional `role` override). Looks up the user's email from the
+     * cached list and re-fetches their profile after so the caller sees
+     * the cleared graduation_year when flipping to alumni_friend.
+     */
+    async setUserRole(userId: string, role: 'alumni' | 'alumni_friend') {
+      try {
+        const target = this.users.find(u => u.id === userId);
+        if (!target || !target.email) {
+          console.error('User not found or missing email');
+          return undefined;
+        }
+        await usersInstance.setUserRole(target.email, role);
+        target.role = role;
+        if (role === 'alumni_friend') {
+          target.graduation_year = null;
+        }
+        return usersInstance.getUserById(userId);
+      } catch (error) {
+        console.error('Failed to change user role:', error);
+        throw error;
+      }
+    },
+
     async changeUserVerificationStatus(userId: string) {
       try {
         const user = this.users.find(u => u.id === userId);

--- a/types/index.ts
+++ b/types/index.ts
@@ -54,13 +54,19 @@ export type Activity = {
     name: string;
 };
 
+/** Wire values for the two supported alumni roles. */
+export type AlumniRole = "alumni" | "alumni_friend";
+
 export type User = {
     id: string;
     email: string;
     hashed_password: string;
     first_name: string;
     last_name: string;
-    graduation_year: string;
+    /** Null for Alumni Friends — the UI shows an "Alumni Friend" chip instead. */
+    graduation_year: string | null;
+    /** Defaults to "alumni" for pre-role rows. */
+    role: AlumniRole;
     location: string;
     biography: string;
     show_location: boolean;
@@ -81,7 +87,8 @@ export type UserListItem = {
     email: string;
     first_name: string;
     last_name: string;
-    graduation_year: string;
+    graduation_year: string | null;
+    role: AlumniRole;
     location: string | null;
     biography: string | null;
     show_location: boolean;
@@ -97,7 +104,8 @@ export type UserProfile = {
     id: string;
     first_name: string;
     last_name: string;
-    graduation_year: string;
+    graduation_year: string | null;
+    role: AlumniRole;
     location: string | null;
     biography: string | null;
     show_location: boolean;


### PR DESCRIPTION
## Summary
Surfaces the new alumni_friend role from [iu-alumni-backend#171](https://github.com/iu-alumni/iu-alumni-backend/pull/171) in the admin portal per FR22, so admins can spot friends at a glance and flip anyone's role from the detail page.

## Changes
- **Types** — `AlumniRole` union, `role` field on `User` / `UserListItem` / `UserProfile`, `graduation_year` widened to `string | null` so friends round-trip correctly.
- **UserTable** — small yellow "Friend" chip next to the name in both the mobile card and the desktop row when `user.role === 'alumni_friend'`.
- **User detail page (`pages/users/[id].vue`)** — header shows an "Alumni Friend" pill when applicable and replaces the "Class of X" subtitle with "Alumni Friend — no graduation year" for friends. Role dropdown (Alumni | Alumni Friend) calls `usersStore.setUserRole`; a `Saving…` hint appears while the request is in flight.
- **API client** — `setUserRole(email, role)` POSTs to `/api/v1/admin/verify { email, role }` — the backend's optional role override on the verify endpoint.
- **Store** — `setUserRole(userId, role)` looks up the email from the cached list, calls the API, patches the local list, returns the refreshed profile so the caller can rebind.

## Depends on
- [iu-alumni-backend#171](https://github.com/iu-alumni/iu-alumni-backend/pull/171) — the role column + verify override.

## Test plan
- [x] `nuxi typecheck` — no new errors (pre-existing warnings on `store/users.ts:81-82` and `vitest.config.ts` untouched).
- [x] eslint clean on all touched files.
- [x] Manual: open `/users`, spot the yellow **Friend** pill next to any alumni_friend user.
- [x] Manual: open a user detail page → dropdown flips role → refresh → subtitle changes accordingly, chip appears/disappears in the list.

Closes #83.