### PR TITLE
Load admin event covers separately

### DIFF
--- a/components/event/EventTable.vue
+++ b/components/event/EventTable.vue
@@ -6,6 +6,7 @@ import type { EventListItem } from '~/types';
 import SmallIcon from '../common/SmallIcon.vue';
 import DefaultIcon from '../common/DefaultIcon.vue';
 import DefaultSeparator from '../common/DefaultSeparator.vue';
+import EventCover from './EventCover.vue';
 
 defineProps<{
   events: EventListItem[]
@@ -55,15 +56,9 @@ const getStatusBadge = (event: EventListItem) => {
         <div class="grid grid-cols-12 items-center px-4 py-4 hover:bg-gray-50">
           <!-- Event Info -->
           <div class="col-span-4 flex items-center space-x-3">
-            <img
-              v-if="event.cover"
-              :src="`data:image/jpeg;base64,${event.cover}`"
-              class="h-10 w-10 flex-shrink-0 rounded-full object-cover"
-              :alt="event.title"
-            >
-            <div
-              v-else
-              class="h-10 w-10 flex-shrink-0 rounded-full bg-gray-200"
+            <EventCover
+              :event-id="event.id"
+              :title="event.title"
             />
             <span class="text-sm font-medium text-gray-900">
               {{ event.title }}

--- a/pages/events/[id].vue
+++ b/pages/events/[id].vue
@@ -8,6 +8,7 @@ import EventParticipants from '~/components/event/EventParticipants.vue';
 import { useEventsStore } from '~/store/events';
 import { useUsersStore } from '~/store/users';
 import type { EventParticipant } from '~/types';
+import eventsApi from '~/api/events';
 
 const route = useRoute()
 const eventsStore = useEventsStore()
@@ -32,12 +33,14 @@ onMounted(async () => {
   const eventId = route.params.id as string
   event.value = await eventsStore.getEventById(eventId)
   if (event.value) {
-    const [participantsData, ownerData] = await Promise.all([
+    const [participantsData, ownerData, coverData] = await Promise.all([
       eventsStore.listParticipants(eventId),
-      usersStore.getUserById(event.value.owner_id)
+      usersStore.getUserById(event.value.owner_id),
+      eventsApi.getEventCover(eventId).catch(() => ({ cover: null })),
     ])
     participants.value = participantsData
     owner.value = ownerData
+    event.value = { ...event.value, cover: coverData.cover }
   }
   isLoading.value = false
 })

--- a/types/index.ts
+++ b/types/index.ts
@@ -18,7 +18,7 @@ export type Event = {
     approved: boolean | null;
 };
 
-/** Event type returned by the admin list endpoint — includes cover for thumbnails. */
+/** Lightweight event returned by the admin list endpoint. */
 export type EventListItem = {
     id: string;
     owner_id: string;
@@ -29,7 +29,6 @@ export type EventListItem = {
     datetime: Date | string;
     cost: number;
     is_online: boolean;
-    cover: string | null;
     approved: boolean | null;
 };
 


### PR DESCRIPTION
## Summary
- Lazily load event covers in the admin list
- Fetch the cover separately on event details

Closes #85 